### PR TITLE
Migrate coverage reporting to octocov

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -1,0 +1,27 @@
+name: octocov
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  octocov:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build container
+        run: docker build .
+
+      - name: Report coverage with octocov
+        uses: k1LoW/octocov-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          config: .octocov.yml

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,10 @@
+# https://github.com/k1LoW/octocov?tab=readme-ov-file#configuration
+diff:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+comment:
+  if: is_pull_request
+report:
+  if: is_default_branch
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # docker-ssh
 
+![Coverage](https://raw.githubusercontent.com/kitsuyui/octocov-central/main/badges/kitsuyui/docker-ssh/coverage.svg)
 [![Docker Hub Pulls](https://img.shields.io/docker/pulls/kitsuyui/docker-ssh.svg)](https://hub.docker.com/r/kitsuyui/docker-ssh/)
 
 OpenSSH client in Docker.


### PR DESCRIPTION
Add octocov configuration and workflow, and update README coverage badge.