### PR TITLE
ci: guard docker release workflow for pull request context

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,6 +1,10 @@
 name: Release Docker Image
 # See also: https://docs.docker.com/build/building/multi-platform/
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review]
@@ -13,6 +17,8 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -33,6 +39,7 @@ jobs:
           images: ${{ env.REGISTRY_IMAGE }}
 
       - name: Login to Docker Hub
+        if: github.event_name == 'release' && !github.event.release.prerelease
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -52,7 +59,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ env.REGISTRY_IMAGE }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,push-by-digest=true,name-canonical=true
           push: false
 
       - name: Build and push by digest
@@ -82,6 +89,10 @@ jobs:
           retention-days: 1
 
   merge:
+    if: github.event_name == 'release' && !github.event.release.prerelease
+    permissions:
+      contents: read
+      actions: read
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
## Summary

- Add explicit workflow permissions for scoped execution.
- Guard Docker Hub login in pull_request context so secret-based auth is not required.
- Add a release-only merge job guard so manifest merge runs only for non-prerelease releases.
- Align build-only step output settings so PR path does not advertise push intent when push is disabled.

## Verification

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker-release.yml'); puts 'ok'`
