### PR TITLE
chore: simplify renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,11 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>kitsuyui/renovate-config"
-  ],
-  // disable pinning and digests for docker images (update semver only)
-  "docker": {
-    "digests": false,
-    "enabled": true,
-    "pinDigests": false
-  },
+  ]
 }


### PR DESCRIPTION
## Summary

- Inherit the shared Renovate preset without the obsolete local Docker manager block.
- Let `github>kitsuyui/renovate-config` own digest pinning behavior.

Fixes #7.

## Verification

- `npx --yes --package renovate renovate-config-validator --no-global .github/renovate.json5`
