### PR TITLE
Pin typos action in spellcheck workflow

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,6 +11,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check spelling
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.46.0
         # typos is a Source code spell checker
         # https://github.com/crate-ci/typos


### PR DESCRIPTION
## Summary
- Pin the spellcheck workflow from crate-ci/typos@master to crate-ci/typos@v1.46.0.
- Keep the spelling check on a released action version instead of tracking the moving master branch.

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/spellcheck.yml"); puts "yaml ok"'
- actionlint .github/workflows/spellcheck.yml