### PR TITLE
Restrict docker build workflow permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,6 +1,8 @@
 name: Test docker build
 on:
   - pull_request
+permissions:
+  contents: read
 jobs:
   buildx:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit read-only `contents` permission to the Docker build check workflow.

## Verification
- `git diff --check`
- `actionlint .github/workflows/docker-build.yml`
- `docker build .`