### PR TITLE
Pin workflow action refs to 40-character commit SHAs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         # cf. https://github.com/marketplace/actions/docker-setup-buildx
 
       - name: Inspect builder

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@9108d679c02a52824376afcf071715fdaaa2a4e4 # main


### PR DESCRIPTION
## Summary

Pin the three external `uses:` references flagged by the supply-chain audit to 40-character commit SHAs:

| File | Before | After |
| --- | --- | --- |
| `docker-build.yml:11` | `actions/checkout@v4` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4` |
| `docker-build.yml:15` | `docker/setup-buildx-action@v3` | `docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3` |
| `spellcheck.yml:8` | `kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main` | `@9108d679c02a52824376afcf071715fdaaa2a4e4 # main` |

The `docker/setup-buildx-action` SHA matches the value already in use elsewhere in this same repository (`docker-release.yml`). The `actions/checkout@v4` SHA is the resolved tip of the existing `v4` tag and matches the value already adopted in another kitsuyui org repo. The `gh-actions-workflows` SHA is the current tip of upstream `main` and matches the value already adopted across the kitsuyui org.

Tag references (`@v3`, `@v4`, `@main`) let upstream silently move content under our CI pipeline. Pinning to a 40-character SHA fixes the supply-chain input.

Renovate already extends `helpers:pinGitHubActionDigests` via `local>kitsuyui/renovate-config`, so future digest updates continue through automated PRs.

## Test plan

- [x] `git diff` confirms only the three `uses:` lines change
- [x] `docker/setup-buildx-action` SHA matches `docker-release.yml` reference in this repo
- [x] `actions/checkout@v4` SHA verified via `gh api repos/actions/checkout/git/refs/tags/v4`