### PR TITLE
Fix reverse forwarding bind address

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,6 @@ services:
     # image: kitsuyui/docker-ssh
     volumes:
       - ./home_ssh:/home/sshuser/.ssh
-    # GatewayPorts=clientspecified is needed in examplehost's /etc/ssh/sshd_config
-    command: ssh -N -R 8080:127.0.0.1:8080 examplehost
+    # GatewayPorts=clientspecified is needed in examplehost's /etc/ssh/sshd_config,
+    # and the client must request a non-loopback bind address.
+    command: ssh -N -R 0.0.0.0:8080:127.0.0.1:8080 examplehost


### PR DESCRIPTION
## Summary
- include an explicit `0.0.0.0` bind address in the reverse forwarding example
- clarify that `GatewayPorts clientspecified` still requires the client to request a non-loopback bind address

## Tests
- `git diff --check`
- `docker compose config`
