### PR TITLE
fix: pin alpine base image to manifest list digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 RUN apk --update add --no-cache openssh-client && \
 addgroup -S sshuser && \
 adduser -S -G sshuser sshuser && \


### PR DESCRIPTION
Pin `FROM alpine:3.21` to its manifest list digest so that Docker's layer cache key includes the exact base image content.

## Problem

`docker build .` uses the layer cache for `RUN apk --update add --no-cache openssh-client` as long as the instruction text and base image tag remain unchanged. The `--update` flag cannot refresh packages when the layer is served from cache, which can leave locally-built images with stale openssh-client versions.

## Fix

Adding `@sha256:<digest>` to the FROM line makes Docker reuse the layer only when the base image digest is identical. When alpine:3.21 receives a security update, renovate will open a PR to update the digest, which invalidates the cache and forces a fresh `apk add` on the next build.

This approach is consistent with the existing practice of pinning workflow action refs to SHA digests.

## Verification

- Digest `sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d` confirmed from Docker Hub as the current multi-arch manifest for alpine:3.21 (updated 2026-04-17).
