### PR TITLE
docs: document SSH volume contract in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,38 @@
 OpenSSH client in Docker.
 Host OS is Alpine Linux.
 
+# Usage
+
+Mount a directory containing your SSH credentials at `/home/sshuser/.ssh`:
+
+```sh
+docker run --rm -v ./home_ssh:/home/sshuser/.ssh kitsuyui/docker-ssh ssh user@host
+```
+
+## What to place in the mounted directory
+
+| File | Purpose | Permission |
+|---|---|---|
+| `id_ed25519` (or `id_rsa`) | Private key for public-key authentication | `600` |
+| `known_hosts` | Trusted host fingerprints (avoids interactive prompt on first connect) | `644` |
+| `config` | Per-host SSH settings (optional) | `600` |
+
+All files must be owned by the user running the container (`sshuser`, uid 100).
+
+## Generate a key pair
+
+The commented-out `keygen` service in `docker-compose.yml` runs `ssh-keygen` inside
+the container and writes the output to `./home_ssh`:
+
+```sh
+mkdir -p home_ssh
+docker compose run --rm keygen
+```
+
+This places `id_ed25519` and `id_ed25519.pub` in `./home_ssh` with the correct
+permissions. Copy the public key to the remote host, then use the composed services
+for port forwarding or any other SSH command.
+
 # LICENSE
 
 The 3-Clause BSD License. See also LICENSE file.


### PR DESCRIPTION
## Summary

Add a `Usage` section to `README.md` that documents the volume contract for `/home/sshuser/.ssh`.

Users mounting `./home_ssh:/home/sshuser/.ssh` previously had no guidance on what files to place there or what permissions they require. This caused silent failures (Permission denied, Host key verification failed) for users unfamiliar with SSH key setup.

## Changes

- Added `Usage` section with `docker run` example
- Added table of required files (`id_ed25519`/`id_rsa`, `known_hosts`, `config`) with their purpose and required permissions
- Added note about file ownership (`sshuser`, uid 100)
- Added step-by-step guide to generate a key pair using the existing `keygen` service in `docker-compose.yml`

## Verification

- `docker build .` passes locally
- README-only change; no code or config modified
