### PR TITLE
fix: prevent tunnel hang on first connect by using StrictHostKeyChecking=accept-new

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ docker run --rm -v ./home_ssh:/home/sshuser/.ssh kitsuyui/docker-ssh ssh user@ho
 
 All files must be owned by the user running the container (`sshuser`, uid 100).
 
+## Host key verification
+
+The container runs non-interactively (no TTY). If `known_hosts` does not contain
+the target host's fingerprint, SSH will wait for interactive input that never arrives
+and the container will appear to hang.
+
+**First-time setup — populate `known_hosts` before starting the tunnel:**
+
+```sh
+ssh-keyscan -H examplehost >> ./home_ssh/known_hosts
+```
+
+Alternatively, the example `docker-compose.yml` services use
+`-o StrictHostKeyChecking=accept-new`, which automatically trusts and records
+the host key on the first connection (TOFU model). This is convenient for
+development but should be replaced with a pre-populated `known_hosts` in
+environments where the remote host's identity must be verified.
+
 ## Generate a key pair
 
 The commented-out `keygen` service in `docker-compose.yml` runs `ssh-keygen` inside

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     # image: kitsuyui/docker-ssh
     volumes:
       - ./home_ssh:/home/sshuser/.ssh
-    command: ssh -N -L 8080:127.0.0.1:8080 examplehost
+    command: ssh -o StrictHostKeyChecking=accept-new -N -L 8080:127.0.0.1:8080 examplehost
 
   example_right_forward_8080:
     # network_mode: host
@@ -23,4 +23,4 @@ services:
       - ./home_ssh:/home/sshuser/.ssh
     # GatewayPorts=clientspecified is needed in examplehost's /etc/ssh/sshd_config,
     # and the client must request a non-loopback bind address.
-    command: ssh -N -R 0.0.0.0:8080:127.0.0.1:8080 examplehost
+    command: ssh -o StrictHostKeyChecking=accept-new -N -R 0.0.0.0:8080:127.0.0.1:8080 examplehost


### PR DESCRIPTION
## Problem

When `known_hosts` is empty, the SSH client inside the container prompts interactively to confirm the host key. Because the container runs non-interactively, this prompt is never answered and the tunnel hangs indefinitely.

## Changes

- **`docker-compose.yml`**: Added `-o StrictHostKeyChecking=accept-new` to both example SSH commands (local-forward and reverse-forward). This makes the SSH client automatically accept and store host keys on first connect instead of waiting for interactive input.
- **`README.md`**: Added a "Host key verification" section that explains:
  1. The non-interactive nature of the container and why a missing `known_hosts` causes a hang.
  2. How to pre-populate `known_hosts` via `ssh-keyscan -H examplehost >> ./home_ssh/known_hosts`.
  3. That the example services use `StrictHostKeyChecking=accept-new` (Trust On First Use) as a development convenience, with a note to replace it with a pre-populated `known_hosts` in security-sensitive environments.

## Trade-off

`StrictHostKeyChecking=accept-new` (TOFU model) eliminates the hang and is convenient for local development and testing. However, it does not verify the host key against a known good value on first connect. For environments where host identity verification matters, users should pre-populate `known_hosts` with `ssh-keyscan` or copy a trusted `known_hosts` file before starting the container.
