### PR TITLE
fix: add SSH keepalive and ExitOnForwardFailure to tunnel examples

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     # image: kitsuyui/docker-ssh
     volumes:
       - ./home_ssh:/home/sshuser/.ssh
-    command: ssh -o StrictHostKeyChecking=accept-new -N -L 8080:127.0.0.1:8080 examplehost
+    command: ssh -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o ExitOnForwardFailure=yes -N -L 8080:127.0.0.1:8080 examplehost
 
   example_right_forward_8080:
     # network_mode: host
@@ -23,4 +23,4 @@ services:
       - ./home_ssh:/home/sshuser/.ssh
     # GatewayPorts=clientspecified is needed in examplehost's /etc/ssh/sshd_config,
     # and the client must request a non-loopback bind address.
-    command: ssh -o StrictHostKeyChecking=accept-new -N -R 0.0.0.0:8080:127.0.0.1:8080 examplehost
+    command: ssh -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o ExitOnForwardFailure=yes -N -R 0.0.0.0:8080:127.0.0.1:8080 examplehost


### PR DESCRIPTION
## What changed

Added three SSH options to both tunnel examples in `docker-compose.yml`:

- `-o ServerAliveInterval=15` — send keepalive probes every 15 seconds
- `-o ServerAliveCountMax=3` — declare the connection dead after 3 missed probes (~45 s total)
- `-o ExitOnForwardFailure=yes` — exit immediately if the port binding fails

Both examples are updated:
- `example_left_forward_8080` (local forward, `-L`)
- `example_right_forward_8080` (remote forward, `-R`)

## Why

Two silent failure modes existed in the tunnel examples:

1. **Broken connection not detected** — if the underlying TCP connection drops (network blip, NAT timeout, remote host restart), `ssh -N` would hang indefinitely without these keepalive options. The tunnel appeared alive but forwarded no traffic.

2. **Failed port bind not detected** — if the remote/local port is already in use, `ssh` without `ExitOnForwardFailure=yes` would silently succeed (exit 0) while the forward was never established.

## New behavior

- If the SSH connection goes silent for ~45 seconds (15 s × 3 probes), `ssh` exits with a non-zero code.
- If the port binding fails at startup, `ssh` exits immediately with a non-zero code.
- Combined with Docker's `restart: always` (or any restart policy), the container is automatically restarted, recovering the tunnel without manual intervention.