### PR TITLE
fix: pin sshuser UID/GID to 200 for deterministic builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 RUN apk --update add --no-cache openssh-client && \
-addgroup -S sshuser && \
-adduser -S -G sshuser sshuser && \
+addgroup -S -g 200 sshuser && \
+adduser -S -u 200 -G sshuser sshuser && \
 mkdir -p /home/sshuser/.ssh && \
 chown sshuser:sshuser /home/sshuser/.ssh && \
 chmod 700 /home/sshuser/.ssh


### PR DESCRIPTION
## Summary

Pin `sshuser` GID/UID to 200 for reproducible image builds.

`addgroup -S` and `adduser -S` without explicit `-g`/`-u` flags let BusyBox
assign the next available system ID. That value depends on the current
`/etc/passwd` and `/etc/group` state in the base image, so it can silently
shift when:
- Alpine ships a patch release that adds a new system account, or
- the `RUN` layer adds another system user before `sshuser`.

Setting `-g 200 -u 200` makes `sshuser`'s identity explicit in the Dockerfile
and stable across rebuilds.

## Changes

- `Dockerfile`: add `-g 200` to `addgroup -S sshuser`
- `Dockerfile`: add `-u 200` to `adduser -S -G sshuser sshuser`

## Verification

`docker build .` passes locally. The `sshuser` user and group are created with
UID/GID 200 as expected.

## Trade-offs

GID/UID 200 is unused in Alpine 3.21 today. If a future Alpine release occupies
200, the build will fail with a clear error rather than silently shifting to a
different ID — which is the desired behavior.
