### PR TITLE
fix: pin openssh-client version via build ARG for cache-aware builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+# Alpine uses 9.9_p2-r0 for OpenSSH 9.9p2, package revision r0.
+# OpenSSH 9.9p2 is a security fix release:
+# https://www.openssh.com/txt/release-9.9p2
 # renovate: datasource=repology depName=alpine_3_21/openssh versioning=loose
 ARG OPENSSH_CLIENT_VERSION=9.9_p2-r0
 RUN apk --update add --no-cache openssh-client=${OPENSSH_CLIENT_VERSION} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
-RUN apk --update add --no-cache openssh-client && \
+# renovate: datasource=repology depName=alpine_3_21/openssh versioning=loose
+ARG OPENSSH_CLIENT_VERSION=9.9_p2-r0
+RUN apk --update add --no-cache openssh-client=${OPENSSH_CLIENT_VERSION} && \
 printf 'BatchMode yes\n' >> /etc/ssh/ssh_config && \
 addgroup -S -g 200 sshuser && \
 adduser -S -u 200 -G sshuser sshuser && \


### PR DESCRIPTION
Add a build ARG for the openssh-client package version and pin it to
`9.9_p2-r0`, replacing the previously unpinned `apk add` invocation.
The version is now part of the Docker layer cache key, so the cached
layer is invalidated when the version changes. A Renovate comment
annotation is attached so the pinned version is automatically updated
by Renovate's repology datasource.
