### PR TITLE
fix: set BatchMode yes in /etc/ssh/ssh_config for non-interactive use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 RUN apk --update add --no-cache openssh-client && \
+printf 'BatchMode yes\n' >> /etc/ssh/ssh_config && \
 addgroup -S -g 200 sshuser && \
 adduser -S -u 200 -G sshuser sshuser && \
 mkdir -p /home/sshuser/.ssh && \

--- a/README.md
+++ b/README.md
@@ -45,11 +45,24 @@ even after `chmod`, the host file sharing layer may not be preserving the POSIX
 mode bits that OpenSSH requires. In that case, use a Docker volume or a Linux
 filesystem that preserves Unix ownership and permissions for private keys.
 
+## Non-interactive (batch) mode
+
+The image sets `BatchMode yes` in `/etc/ssh/ssh_config`. In batch mode, SSH
+exits immediately with an error instead of waiting for interactive input such as
+a passphrase prompt or a password prompt. This ensures the container never hangs
+in a CI/CD pipeline.
+
+If you need an interactive SSH session, override the setting at the command line:
+
+```sh
+docker run --rm -it -v ./home_ssh:/home/sshuser/.ssh kitsuyui/docker-ssh \
+  ssh -o BatchMode=no user@host
+```
+
 ## Host key verification
 
 The container runs non-interactively (no TTY). If `known_hosts` does not contain
-the target host's fingerprint, SSH will wait for interactive input that never arrives
-and the container will appear to hang.
+the target host's fingerprint, SSH exits with an error instead of hanging.
 
 **First-time setup — populate `known_hosts` before starting the tunnel:**
 


### PR DESCRIPTION
The container is designed for non-interactive (TTY-less) use, but SSH defaults
to interactive mode. Without `BatchMode yes`, SSH hangs indefinitely on
passphrase or password prompts in CI/CD pipelines where no TTY is present.

## Changes

- **Dockerfile**: append `BatchMode yes` to `/etc/ssh/ssh_config` after
  installing openssh-client. This applies to all SSH invocations in the
  container, not just the `docker-compose.yml` examples.
- **README.md**: add a "Non-interactive (batch) mode" section documenting the
  default behavior and how to override it (`-o BatchMode=no`) for interactive
  sessions. Update the "Host key verification" section to reflect that SSH now
  exits with an error instead of hanging when the host key is unknown.

## Verification

- `docker build .` passes locally.
- `BatchMode yes` confirmed present in `/etc/ssh/ssh_config` inside the built
  image (`grep -i batchmode /etc/ssh/ssh_config` → `BatchMode yes`).

## Trade-offs

Users with passphrase-protected keys will now get an immediate authentication
error rather than a passphrase prompt. They can override with
`ssh -o BatchMode=no` or a per-host `~/.ssh/config` entry.
