### PR TITLE
fix: decouple keygen chown from Dockerfile uid by using username

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,14 +15,14 @@ services:
       - -c
       - |
         mkdir -p /home/sshuser/.ssh
-        chown 200:200 /home/sshuser/.ssh
+        chown sshuser:sshuser /home/sshuser/.ssh
         chmod 700 /home/sshuser/.ssh
         if [ -e /home/sshuser/.ssh/id_ed25519 ]; then
           echo "/home/sshuser/.ssh/id_ed25519 already exists; remove it before regenerating." >&2
           exit 1
         fi
         ssh-keygen -t ed25519 -f /home/sshuser/.ssh/id_ed25519 -N ""
-        chown 200:200 /home/sshuser/.ssh/id_ed25519 /home/sshuser/.ssh/id_ed25519.pub
+        chown sshuser:sshuser /home/sshuser/.ssh/id_ed25519 /home/sshuser/.ssh/id_ed25519.pub
         chmod 600 /home/sshuser/.ssh/id_ed25519
         chmod 644 /home/sshuser/.ssh/id_ed25519.pub
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `200:200` with `sshuser:sshuser` in the keygen service `chown` commands in `docker-compose.yml`

## Problem

The keygen service in `docker-compose.yml` hardcodes the numeric UID/GID `200:200` when setting file ownership. This number is independently defined in the `Dockerfile` (`addgroup -S -g 200 sshuser` / `adduser -S -u 200 -G sshuser sshuser`). The two files have no shared constant: if the UID is changed in the `Dockerfile`, the `docker-compose.yml` keygen script must be updated separately — and missing that update would cause SSH key permission failures at startup (OpenSSH rejects keys not owned by the expected user).

## Change

Use the symbolic username `sshuser:sshuser` instead of `200:200` in the `chown` calls. The keygen service runs as root (`user: "0:0"`), so it can resolve the username from the container's `/etc/passwd`. Because the service builds from the same `Dockerfile`, `sshuser` always maps to the correct UID at runtime, regardless of the numeric value.

## Validation

- `docker build .` passes without changes to the `Dockerfile`
- Functional behavior is unchanged: ownership is set to the same `sshuser` account, referenced by name rather than number
