### PR TITLE
Sort manifest digest sources before release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -136,9 +136,9 @@ jobs:
             tag_args+=("-t" "$tag")
           done
           sources=()
-          for digest in *; do
+          while IFS= read -r digest; do
             sources+=("${REGISTRY_IMAGE}@sha256:${digest}")
-          done
+          done < <(printf '%s\n' * | LC_ALL=C sort)
           docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
 
       - name: Inspect image


### PR DESCRIPTION
## Summary
- sort downloaded digest filenames before creating the multi-platform manifest list
- use C-locale ordering so release reruns pass image sources to Buildx consistently

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-release.yml")'`
- `awk '/          mapfile -t tags/{flag=1} flag{print substr($0,11)} /          docker buildx imagetools create/{exit}' .github/workflows/docker-release.yml | bash -n`
- `actionlint .github/workflows/docker-release.yml .github/workflows/docker-build.yml .github/workflows/spellcheck.yml .github/workflows/gitignore-in.yml`
- `git diff --check`
