### PR TITLE
Guard key generation against symlinks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,14 +17,22 @@ services:
         mkdir -p /home/sshuser/.ssh
         chown sshuser:sshuser /home/sshuser/.ssh
         chmod 700 /home/sshuser/.ssh
-        if [ -e /home/sshuser/.ssh/id_ed25519 ]; then
-          echo "/home/sshuser/.ssh/id_ed25519 already exists; remove it before regenerating." >&2
+        private_key_path=/home/sshuser/.ssh/id_ed25519
+        public_key_path="$${private_key_path}.pub"
+        for key_path in "$$private_key_path" "$$public_key_path"; do
+          if [ -L "$$key_path" ]; then
+            echo "$$key_path must not be a symlink; remove it before regenerating." >&2
+            exit 1
+          fi
+        done
+        if [ -e "$$private_key_path" ]; then
+          echo "$$private_key_path already exists; remove it before regenerating." >&2
           exit 1
         fi
-        ssh-keygen -t ed25519 -f /home/sshuser/.ssh/id_ed25519 -N ""
-        chown sshuser:sshuser /home/sshuser/.ssh/id_ed25519 /home/sshuser/.ssh/id_ed25519.pub
-        chmod 600 /home/sshuser/.ssh/id_ed25519
-        chmod 644 /home/sshuser/.ssh/id_ed25519.pub
+        ssh-keygen -t ed25519 -f "$$private_key_path" -N ""
+        chown sshuser:sshuser "$$private_key_path" "$$public_key_path"
+        chmod 600 "$$private_key_path"
+        chmod 644 "$$public_key_path"
 
   example_left_forward_8080:
     profiles:


### PR DESCRIPTION
## Summary
- reject symlinked key output paths before generating a new keypair
- reuse the validated key paths for ssh-keygen and permission updates
- keep the existing overwrite guard for an existing private key

## Verification
- `docker compose --profile setup config`
- `docker build .`
- `docker compose --profile setup run --rm keygen` rejects a symlinked `id_ed25519`
- `git diff --check`
