### PR TITLE
fix: remove --update flag from apk to preserve build reproducibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
-RUN apk --update add --no-cache openssh-client && \
+RUN apk add --no-cache openssh-client && \
 printf 'BatchMode yes\n' >> /etc/ssh/ssh_config && \
 addgroup -S -g 200 sshuser && \
 adduser -S -u 200 -G sshuser sshuser && \


### PR DESCRIPTION
## Summary

The `apk --update add` invocation was causing `apk` to fetch a fresh package
index from the network at build time. This defeats the reproducibility guarantee
provided by the SHA256 digest-pinned base image (`alpine:3.21@sha256:...`):
even with the digest locked, the resolved version of `openssh-client` could
change between builds if the package index was refreshed independently.

## Change

Remove the `--update` flag so that `apk add --no-cache` uses the package index
already embedded in the pinned base image. The resolved package set is now
determined solely by the digest-pinned base, making builds reproducible.

## Trade-off

Without `--update`, the installed version of `openssh-client` is whatever is
bundled with the pinned Alpine digest. To pick up a newer package version,
update the base image digest (i.e., bump `alpine:3.21@sha256:...`) rather than
relying on a network index refresh at build time. This is the expected workflow
for a digest-pinned image and is consistent with how this repository already
manages the base image.
