### PR TITLE
Guard keygen against partial key-pair states

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ docker compose --profile setup run --rm keygen
 ```
 
 This places `id_ed25519` and `id_ed25519.pub` in `./home_ssh` with ownership and
-permissions suitable for the container user. If `id_ed25519` already exists, the
-setup task exits instead of overwriting it.
+permissions suitable for the container user. If either key file already exists,
+the setup task exits instead of overwriting it. Remove the existing key pair, or
+restore the missing half of a partial key pair, before running key generation
+again.
 
 Copy the public key to the remote host, then start one forwarding example at a
 time:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,14 @@ services:
             exit 1
           fi
         done
-        if [ -e "$$private_key_path" ]; then
-          echo "$$private_key_path already exists; remove it before regenerating." >&2
+        if [ -e "$$private_key_path" ] || [ -e "$$public_key_path" ]; then
+          if [ -e "$$private_key_path" ] && [ -e "$$public_key_path" ]; then
+            echo "$$private_key_path and $$public_key_path already exist; remove both before regenerating." >&2
+          elif [ -e "$$private_key_path" ]; then
+            echo "$$private_key_path exists but $$public_key_path is missing; restore the missing public key or remove the private key before regenerating." >&2
+          else
+            echo "$$public_key_path exists but $$private_key_path is missing; remove the stale public key before regenerating." >&2
+          fi
           exit 1
         fi
         ssh-keygen -t ed25519 -f "$$private_key_path" -N ""


### PR DESCRIPTION
## Summary

- Check both `id_ed25519` and `id_ed25519.pub` before generating a new key pair.
- Report explicit recovery guidance for private-only and public-only partial key-pair states.
- Update the README key generation note to describe the partial key-pair guard.

## Verification

- `docker compose --profile setup config`
- `docker build .`
- `shellcheck -s sh` on the embedded keygen script
- `docker compose --profile setup run --rm keygen` with only `id_ed25519`
- `docker compose --profile setup run --rm keygen` with only `id_ed25519.pub`

## Notes

- `docker compose config` without a profile reports no active services because every service in this compose file is profile-gated.
