### PR TITLE
Document Docker network isolation for -L port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,54 @@ the host key on the first connection (TOFU model). This is convenient for
 development but should be replaced with a pre-populated `known_hosts` in
 environments where the remote host's identity must be verified.
 
+## Port forwarding and Docker network isolation
+
+SSH local forwarding (`-L`) and remote forwarding (`-R`) behave differently
+inside a Docker container.
+
+### Local forward (`-L`)
+
+```
+ssh -N -L 8080:127.0.0.1:8080 examplehost
+```
+
+`-L` binds the tunnel's local endpoint inside the **container**. With Docker's
+default bridge network, the container's `127.0.0.1` is not reachable from the
+Docker host. Running this command inside the container creates a tunnel that is
+only accessible from within the container, not from the host OS.
+
+To reach the tunnel from the Docker host, use one of the following approaches:
+
+**Option A — host network mode** (`network_mode: host` in `docker-compose.yml`)
+
+The container shares the host's network stack. The tunnel binds to host
+`127.0.0.1:8080` directly. Simple, but the container loses network isolation.
+
+**Option B — port mapping with all-interface bind**
+
+Change the bind address to `0.0.0.0` and add a `ports:` mapping:
+
+```yaml
+ports:
+  - "127.0.0.1:8080:8080"
+command: ssh ... -N -L 0.0.0.0:8080:127.0.0.1:8080 examplehost
+```
+
+Docker proxies `host:8080` → `container:8080`. The tunnel must listen on all
+container interfaces (`0.0.0.0`) rather than only on `127.0.0.1` for the proxy
+to reach it. Network isolation is preserved; the port is exposed only on the
+specified host address.
+
+### Remote forward (`-R`)
+
+```
+ssh -N -R 0.0.0.0:8080:127.0.0.1:8080 examplehost
+```
+
+`-R` binds the port on the **remote host** (examplehost), not locally. Docker
+network isolation does not affect which ports are reachable on the remote side,
+so `network_mode: host` is not required for remote forwarding.
+
 ## Generate a key pair
 
 The `keygen` service in `docker-compose.yml` runs as a one-shot setup task and

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,21 @@ services:
   example_left_forward_8080:
     profiles:
       - forwarding
+    # -L (local forward) binds the tunnel port on the container's loopback by
+    # default. Docker's bridge network isolates the container, so the Docker
+    # host cannot reach that loopback port directly.
+    #
+    # To make the tunnel accessible from the Docker host, choose one option:
+    #
+    # Option A — enable host network mode (uncomment the line below). The
+    # container shares the host's network stack, so the tunnel appears on
+    # host 127.0.0.1:8080 directly. Simple, but removes network isolation.
+    #
+    # Option B — bind the tunnel to all container interfaces and expose the
+    # port via Docker's port mapping. Change the command to
+    # "-L 0.0.0.0:8080:127.0.0.1:8080" and add a "ports:" section. Docker
+    # proxies host:8080 → container:8080. Preserves network isolation.
+    #
     # network_mode: host
     build: .
     # image: kitsuyui/docker-ssh
@@ -53,6 +68,9 @@ services:
   example_right_forward_8080:
     profiles:
       - forwarding
+    # -R (remote forward) binds the port on the remote host (examplehost), not
+    # locally. Docker network isolation does not affect reachability from the
+    # Docker host for this direction, so network_mode: host is not required here.
     # network_mode: host
     build: .
     # image: kitsuyui/docker-ssh


### PR DESCRIPTION
## Summary

`-L` local port forwarding inside a Docker container binds the tunnel port to the container's loopback interface (`127.0.0.1`), which is not reachable from the Docker host due to Docker's bridge network isolation. The `docker-compose.yml` had `# network_mode: host` commented out without explaining why it is needed or what alternatives exist. The README had no mention of this Docker network isolation behavior.

## Changes

**`docker-compose.yml`**
- Added inline comments to `example_left_forward_8080` explaining:
  - Why `-L` tunnels are inaccessible from the Docker host by default
  - Option A: `network_mode: host` (shares host network, no isolation)
  - Option B: `ports:` mapping with `-L 0.0.0.0:8080:...` (preserves isolation)
- Added a comment to `example_right_forward_8080` explaining that `-R` is not affected by this isolation (binds on the remote host, not locally)

**`README.md`**
- Added a new section "Port forwarding and Docker network isolation" documenting:
  - Why `-L` binds inside the container and is unreachable from the host
  - Both options for making it reachable (host network mode vs. port mapping)
  - Why `-R` does not have this asymmetry

## Verification

- `typos`: 0 findings on the full repository
- No functional code changes; documentation and comments only

## Trade-offs

This is a documentation-only fix. Users who need the tunnel accessible from the host must still change the configuration themselves (choosing Option A or B). The functional config change (adding `ports:` or enabling `network_mode: host`) is deferred as it requires a design choice about network isolation.
