### PR TITLE
feat: add entrypoint wrapper for SSH tunnel startup logging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 *
+!entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ adduser -S -u 200 -G sshuser sshuser && \
 mkdir -p /home/sshuser/.ssh && \
 chown sshuser:sshuser /home/sshuser/.ssh && \
 chmod 700 /home/sshuser/.ssh
+COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 USER sshuser
 WORKDIR /home/sshuser
 VOLUME /home/sshuser/.ssh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,20 @@ services:
     # image: kitsuyui/docker-ssh
     volumes:
       - ./home_ssh:/home/sshuser/.ssh
-    command: ssh -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o ExitOnForwardFailure=yes -N -L 8080:127.0.0.1:8080 examplehost
+    command:
+      - ssh
+      - -o
+      - StrictHostKeyChecking=accept-new
+      - -o
+      - ServerAliveInterval=15
+      - -o
+      - ServerAliveCountMax=3
+      - -o
+      - ExitOnForwardFailure=yes
+      - -N
+      - -L
+      - 8080:127.0.0.1:8080
+      - examplehost
 
   example_right_forward_8080:
     profiles:
@@ -78,4 +91,17 @@ services:
       - ./home_ssh:/home/sshuser/.ssh
     # GatewayPorts=clientspecified is needed in examplehost's /etc/ssh/sshd_config,
     # and the client must request a non-loopback bind address.
-    command: ssh -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o ExitOnForwardFailure=yes -N -R 0.0.0.0:8080:127.0.0.1:8080 examplehost
+    command:
+      - ssh
+      - -o
+      - StrictHostKeyChecking=accept-new
+      - -o
+      - ServerAliveInterval=15
+      - -o
+      - ServerAliveCountMax=3
+      - -o
+      - ExitOnForwardFailure=yes
+      - -N
+      - -R
+      - 0.0.0.0:8080:127.0.0.1:8080
+      - examplehost

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# When the first argument is "ssh", log the invocation timestamp and merge
+# SSH's verbose output (stderr) into stdout so docker logs captures it.
+# All other commands (e.g. the keygen sh script) run unmodified.
+if [ "${1:-}" = "ssh" ]; then
+    printf '%s [docker-ssh] starting: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+    exec "$@" -v 2>&1
+fi
+exec "$@"


### PR DESCRIPTION
## Summary

`ssh -N` produces no stdout/stderr when a tunnel is established. `docker logs` shows nothing while the tunnel runs, making it impossible to distinguish "connected and forwarding" from "just started but not yet connected".

## Changes

- Add `entrypoint.sh`: runs before every `ssh` invocation, prints a timestamped startup line, appends `-v` to the SSH args, and merges stderr into stdout (`2>&1`) so OpenSSH's connection messages (`Authenticated`, `Requesting forwarding`) appear in `docker logs`.
- Non-`ssh` commands (e.g. the `keygen` shell script) pass through the entrypoint unmodified.
- Update `Dockerfile`: `COPY --chmod=755 entrypoint.sh` + `ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]`.
- Update `.dockerignore`: add `!entrypoint.sh` exception (the file currently excludes everything with `*`).
- Convert forwarding service `command:` from inline strings to YAML list form so Docker passes args directly to the entrypoint rather than wrapping them in a shell.

## Example docker logs output (after this change)

```
2026-05-24T18:30:00Z [docker-ssh] starting: ssh -o StrictHostKeyChecking=accept-new ... -N -L 8080:127.0.0.1:8080 examplehost
debug1: Connecting to examplehost port 22.
debug1: Connection established.
debug1: Authenticated to examplehost ([...]:22) using "publickey".
debug1: Local connections to 127.0.0.1:8080 forwarded to remote address 127.0.0.1:8080
debug1: Entering interactive session.
```

## Verification

- `docker build .` succeeds
- `docker run --rm <image> ssh --version` prints startup log then SSH usage (SSH rejects `--version`; expected)
- `docker run --rm <image> sh -c 'echo hello'` prints `hello` with no entrypoint noise (non-ssh passthrough)