### PR TITLE
fix: sync gh-actions-workflows refs to consistent SHA

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: write
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@716b321a761d14b8fa6f2ebe61fd55b763f9dade

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@9108d679c02a52824376afcf071715fdaaa2a4e4 # main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@716b321a761d14b8fa6f2ebe61fd55b763f9dade


### PR DESCRIPTION
## Summary

Both workflow files referenced different commits of
`kitsuyui/gh-actions-workflows`, causing inconsistency in which
upstream fixes and updates each workflow received.

- `.github/workflows/gitignore-in.yml`: `3717c78` → `716b321a`
- `.github/workflows/spellcheck.yml`: `9108d67` → `716b321a`

Both now pin to the same commit (`716b321a`), which is the current
`main` HEAD of `kitsuyui/gh-actions-workflows`.

## Verification

- `actionlint` reports no issues on the updated workflow files.
- Both referenced workflow files (`gitignore-in.yml`, `spellcheck.yml`)
  exist at commit `716b321a` in `kitsuyui/gh-actions-workflows`.
