### PR TITLE
feat: add HEALTHCHECK and restart policy to detect broken tunnels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ chown sshuser:sshuser /home/sshuser/.ssh && \
 chmod 700 /home/sshuser/.ssh
 COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+# Verify the ssh process is still running. A hung connection keeps the process
+# alive but passes this check; the ServerAlive* options in docker-compose.yml
+# are responsible for exiting on a broken tunnel so the container restarts.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD pgrep -x ssh > /dev/null
 USER sshuser
 WORKDIR /home/sshuser
 VOLUME /home/sshuser/.ssh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
   example_left_forward_8080:
     profiles:
       - forwarding
+    restart: on-failure
     # -L (local forward) binds the tunnel port on the container's loopback by
     # default. Docker's bridge network isolates the container, so the Docker
     # host cannot reach that loopback port directly.
@@ -81,6 +82,7 @@ services:
   example_right_forward_8080:
     profiles:
       - forwarding
+    restart: on-failure
     # -R (remote forward) binds the port on the remote host (examplehost), not
     # locally. Docker network isolation does not affect reachability from the
     # Docker host for this direction, so network_mode: host is not required here.


### PR DESCRIPTION
## Problem

The container state (running/stopped) and the SSH tunnel state
(active/broken) can diverge without Docker detecting the discrepancy:

- Docker has no `HEALTHCHECK` to observe tunnel liveness beyond process
  existence.
- The example services in `docker-compose.yml` have no `restart:` policy
  (default `no`), so a container that exits due to a broken tunnel is not
  automatically restarted.

When SSH exits because of a broken connection (`ServerAliveCountMax`
exhausted, `ExitOnForwardFailure` triggered), the container stops — but
without a `restart:` policy, it stays stopped indefinitely.

## Changes

**`Dockerfile`** — add `HEALTHCHECK`:

```dockerfile
HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
  CMD pgrep -x ssh > /dev/null
```

Marks the container `unhealthy` if the `ssh` process disappears, making
the broken state visible in `docker ps` and to monitoring tools.

**`docker-compose.yml`** — add `restart: on-failure` to both forwarding
example services:

```yaml
restart: on-failure
```

When SSH exits with a non-zero code (tunnel dropped), Compose restarts the
container automatically. `on-failure` is preferred over `always` so that a
deliberate `docker compose stop` is not countered.

## Verification

- `docker build .` passes
- No lint / test commands defined in this repo

## Trade-offs

The `HEALTHCHECK` detects process death but not a hung connection where the
SSH process is still alive but the tunnel is frozen. The existing
`ServerAliveInterval=15` / `ServerAliveCountMax=3` options in the example
commands handle that case by causing SSH to exit after ~45 s, which then
triggers the `restart: on-failure` policy.