### PR TITLE
Quote release workflow shell values

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -28,8 +28,10 @@ jobs:
           - linux/arm64
     steps:
       - name: Prepare
+        env:
+          MATRIX_PLATFORM: ${{ matrix.platform }}
         run: |
-          platform=${{ matrix.platform }}
+          platform="${MATRIX_PLATFORM}"
           echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
       - name: Docker meta
@@ -74,10 +76,13 @@ jobs:
 
       - name: Export digest
         if: github.event_name == 'release' && !github.event.release.prerelease
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          DIGESTS_DIR: ${{ runner.temp }}/digests
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          mkdir -p "${DIGESTS_DIR}"
+          digest="${BUILD_DIGEST}"
+          touch "${DIGESTS_DIR}/${digest#sha256:}"
 
       - name: Upload digest
         if: github.event_name == 'release' && !github.event.release.prerelease
@@ -143,5 +148,8 @@ jobs:
 
       - name: Inspect image
         if: github.event_name == 'release' && !github.event.release.prerelease
+        env:
+          IMAGE_VERSION: ${{ steps.meta.outputs.version }}
+          REGISTRY_IMAGE: ${{ env.REGISTRY_IMAGE }}
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect "${REGISTRY_IMAGE}:${IMAGE_VERSION}"


### PR DESCRIPTION
## Summary
- Pass workflow metadata values through step environment variables before shell use.
- Quote release workflow shell expansions for platform preparation, digest export, and image inspection.
- Keep the existing release build and manifest behavior unchanged.

## Validation
- `git diff --check`
- `actionlint .github/workflows/docker-release.yml`
- Ruby YAML load for `.github/workflows/docker-release.yml`
- `docker compose config` (passes with the existing obsolete `version` warning)
- `docker build .`

## Notes
- I did not run a real GitHub Release event locally; the PR CI remains the source of truth for workflow execution.
