### PR TITLE
ci: add timeout-minutes to docker-build and docker-release workflows

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,7 @@ permissions:
 jobs:
   buildx:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +95,7 @@ jobs:
       contents: read
       actions: read
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       - build
     steps:


### PR DESCRIPTION
## Summary

Add `timeout-minutes` to all jobs in `docker-build.yml` and `docker-release.yml` to
prevent runaway CI runs when Docker operations hang.

| workflow | job | timeout |
|---|---|---|
| `docker-build.yml` | `buildx` | 20 min |
| `docker-release.yml` | `build` | 30 min |
| `docker-release.yml` | `merge` | 10 min |

## Problem

Without an explicit `timeout-minutes`, GitHub Actions defaults to 360 minutes (6 hours).
If `apk add`, a base image pull, or QEMU emulation hangs, the CI run blocks for up to
6 hours, delaying feedback and consuming billing minutes.

## Fix

Added conservative `timeout-minutes` values based on expected build duration:
- `buildx` (single-platform build test): 20 minutes
- `build` (multi-platform with QEMU, amd64 + arm64): 30 minutes
- `merge` (manifest list creation): 10 minutes

## Verification

- Changes are additive-only; no build logic altered
- yamllint warnings in the files are pre-existing (unrelated to this change)