### PR TITLE
ci: add concurrency control to docker-release workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,7 @@ permissions:
 jobs:
   buildx:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +95,7 @@ jobs:
       contents: read
       actions: read
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       - build
     steps:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -12,6 +12,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
+
 env:
   REGISTRY_IMAGE: kitsuyui/docker-ssh
 


### PR DESCRIPTION
## Summary

Add a top-level `concurrency` block to `.github/workflows/docker-release.yml` to prevent stale CI runs from accumulating on the same branch or PR.

## Changes

- Added `concurrency.group` using `${{ github.workflow }}-${{ github.ref }}` to scope runs per workflow+ref pair.
- Set `cancel-in-progress: ${{ github.event_name != 'release' }}` so that:
  - `pull_request` runs are cancelled when a newer push arrives (reduces wasted runner time and noisy failure notifications).
  - `release` runs are **not** cancelled, avoiding interruption of a Docker image push mid-flight.

## Verification

- `actionlint`: no findings
