### PR TITLE
docs: document example_right_forward_8080 compose service in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,11 @@ Copy the public key to the remote host, then start one forwarding example at a
 time:
 
 ```sh
+# Local forward: expose examplehost:8080 on the Docker host
 docker compose --profile forwarding up example_left_forward_8080
+
+# Remote forward: expose localhost:8080 on examplehost:8080
+docker compose --profile forwarding up example_right_forward_8080
 ```
 
 Keep key generation separate from the forwarding services so tunnels never start


### PR DESCRIPTION
`docker-compose.yml` defines two forwarding services — `example_left_forward_8080` and
`example_right_forward_8080` — but the README only named the left-forward service in
its command example, leaving the right-forward service undiscoverable by name.

This change adds `example_right_forward_8080` to the compose command example so both
services appear side-by-side with a one-line comment explaining the forwarding direction.

## Changes

- `README.md`: add `example_right_forward_8080` alongside the existing
  `example_left_forward_8080` example, with brief comments distinguishing local vs
  remote forwarding.

## Verification

- `typos` reports no spelling issues on the updated README.
- Docker image build is unaffected (README-only change).
