### PR TITLE
chore: add lefthook for local checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,23 @@ docker compose --profile forwarding up example_left_forward_8080
 Keep key generation separate from the forwarding services so tunnels never start
 before the mounted SSH directory has been prepared.
 
+## Development
+
+Install [lefthook](https://github.com/evilmartians/lefthook) and register the hooks:
+
+```sh
+lefthook install
+```
+
+The hooks run two fast static checks before every commit and push:
+
+- **hadolint** — lints the `Dockerfile` for best-practice issues
+- **shellcheck** — analyses `entrypoint.sh` for shell script bugs
+
+These checks are intentionally lightweight and run entirely locally so problems
+surface before they reach CI. The full `docker build` is left to CI because it
+requires a Docker daemon and takes considerably longer.
+
 # LICENSE
 
 The 3-Clause BSD License. See also LICENSE file.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: hadolint
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; hadolint Dockerfile
+    - name: shellcheck
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; shellcheck entrypoint.sh
+pre-push:
+  jobs:
+    - name: hadolint
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; hadolint Dockerfile
+    - name: shellcheck
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; shellcheck entrypoint.sh


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` with two fast static checks as `pre-commit` and `pre-push` hooks:
  - **hadolint** — lints `Dockerfile` for Dockerfile best-practice issues
  - **shellcheck** — analyses `entrypoint.sh` for shell script bugs
- Adds a `## Development` section to `README.md` explaining how to run `lefthook install` and what each hook does

## Why not `docker build` in the hook?

`docker build` requires a Docker daemon, can take minutes, and is already covered by CI. The hooks here are intentional lightweight checks that run in under a second and need no daemon — they surface formatting and script issues immediately on the developer's machine, before a push even reaches CI.

## Files changed

- `lefthook.yml` (new file)
- `README.md` (added `## Development` section before `# LICENSE`)

## Test plan

- [ ] Clone repo and run `lefthook install`
- [ ] Verify `hadolint Dockerfile` exits 0
- [ ] Verify `shellcheck entrypoint.sh` exits 0
- [ ] Make a test commit and confirm both hooks run and pass