### PR TITLE
ci: add runtime smoke test to verify ssh is executable

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,4 +25,8 @@ jobs:
 
       - name: Build
         run: |
-          docker build .
+          docker build --load -t docker-ssh-test .
+
+      - name: Smoke test
+        run: |
+          docker run --rm docker-ssh-test ssh -V


### PR DESCRIPTION
The `docker-build.yml` CI workflow only verified that the image could be *built*, but not that it could actually *run*. A broken runtime dependency (e.g. `openssh-client`) or a misconfigured user/entrypoint setup would pass CI undetected.

This change adds:
1. `--load -t docker-ssh-test` to the build step so the image is available in the local Docker daemon.
2. A "Smoke test" step that runs `docker run --rm docker-ssh-test ssh -V`, exercising the entrypoint and verifying the `ssh` binary is accessible inside the container.
