### PR TITLE
security: add container hardening to docker-compose.yml services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     build: .
     # image: kitsuyui/docker-ssh
     user: "0:0"
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - ./home_ssh:/home/sshuser/.ssh
     command:
@@ -62,6 +64,13 @@ services:
     # network_mode: host
     build: .
     # image: kitsuyui/docker-ssh
+    cap_drop:
+      - ALL
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp
     volumes:
       - ./home_ssh:/home/sshuser/.ssh
     command:
@@ -89,6 +98,13 @@ services:
     # network_mode: host
     build: .
     # image: kitsuyui/docker-ssh
+    cap_drop:
+      - ALL
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp
     volumes:
       - ./home_ssh:/home/sshuser/.ssh
     # GatewayPorts=clientspecified is needed in examplehost's /etc/ssh/sshd_config,


### PR DESCRIPTION
## Summary

Applies least-privilege container hardening to all Compose services to reduce the attack surface if a container is compromised.

- **SSH client services** (`example_left_forward_8080`, `example_right_forward_8080`):
  - `cap_drop: [ALL]` — port forwarding requires no Linux capabilities
  - `read_only: true` — no writes needed outside the bind-mounted `.ssh` volume
  - `security_opt: [no-new-privileges:true]` — prevents setuid-based privilege escalation
  - `tmpfs: [/tmp]` — provides a writable `/tmp` for any runtime needs while keeping the root filesystem read-only

- **`keygen` service** (runs as root to transfer key ownership):
  - `security_opt: [no-new-privileges:true]` — prevents setuid escalation
  - `cap_drop` is not added: keygen needs `CAP_CHOWN` and `CAP_FOWNER` to `chown` and `chmod` generated keys to `sshuser`; dropping all capabilities without the correct `cap_add` would break key generation.

## Why not full cap_drop for keygen?

The `keygen` service runs as `user: "0:0"` (root) specifically to call `chown sshuser:sshuser` on generated keys and then `chmod` them after they are owned by `sshuser`. Both operations require capabilities (`CAP_CHOWN` and `CAP_FOWNER`) that are not needed by the SSH forwarding services. Limiting keygen to `no-new-privileges` keeps the fix minimal and safe; a follow-up can add `cap_drop: [ALL]` with an explicit `cap_add: [CHOWN, FOWNER]` if tighter hardening of keygen is desired.

## Verification

- `docker build .` passes
- `docker compose --profile setup --profile forwarding config` validates the compose file with all hardening options parsed correctly