### PR TITLE
Pin Renovate shared preset to current commit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>kitsuyui/renovate-config"
+    "github>kitsuyui/renovate-config#cdad3c71e34e5abadf909c996906011bbc2b5725"
   ]
 }


### PR DESCRIPTION
## Summary

Pin the shared Renovate preset reference to the current `kitsuyui/renovate-config` commit so this repository's Renovate behavior changes only through an explicit config update.

## Verification

- `git diff --check`
- `npx --yes --package renovate renovate-config-validator .github/renovate.json5`
- `LOG_LEVEL=debug npx --yes --package renovate renovate --platform=local --dry-run=lookup --print-config --repository-cache=disabled --require-config=required`
- `docker compose config`
- `docker build --load -t docker-ssh-test .`
- `docker run --rm docker-ssh-test ssh -V`
- `actionlint .github/workflows/*.yml`
- `typos .github/renovate.json5`
