### PR TITLE
fix: route -V flag to ssh for version discovery

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 # When the first argument is "ssh", log the invocation timestamp and merge
 # SSH's verbose output (stderr) into stdout so docker logs captures it.
+# Pass -V through to ssh so "docker run kitsuyui/docker-ssh -V" prints the version.
 # All other commands (e.g. the keygen sh script) run unmodified.
+if [ "${1:-}" = "-V" ]; then
+    exec ssh -V
+fi
 if [ "${1:-}" = "ssh" ]; then
     printf '%s [docker-ssh] starting: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
     exec "$@" -v 2>&1


### PR DESCRIPTION
## Summary

`docker run kitsuyui/docker-ssh -V` previously failed because the entrypoint
passed `-V` verbatim to `exec`, which tried to execute a program literally named
`-V`. This made it impossible to discover the SSH client version through the
container.

This change adds a short-circuit in `entrypoint.sh`: when the first argument is
`-V`, the entrypoint hands off directly to `ssh -V` so users can check the
bundled OpenSSH version without wrapping the flag in a full `ssh -V` invocation.

## Changes

- `entrypoint.sh`: add `-V` branch before the existing `ssh` branch

## Verification

- `shellcheck entrypoint.sh` — clean (no new warnings)
- Expected behavior after this change:
  - `docker run kitsuyui/docker-ssh -V` → prints OpenSSH version to stderr
  - `docker run kitsuyui/docker-ssh ssh ...` → unchanged (tunnel logging still active)
  - `docker run kitsuyui/docker-ssh sh -eu -c ...` → unchanged (keygen pass-through)