### PR TITLE
docs: document build vs Docker Hub image switch in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
 version: '3'
+# Image source: each service defaults to a local build from the Dockerfile.
+# To use the pre-built Docker Hub image instead, swap the two lines in each
+# service: comment out `build: .` and uncomment `# image: kitsuyui/docker-ssh`.
 services:
 
   keygen:


### PR DESCRIPTION
## Summary

`docker-compose.yml` has three services each with `build: .` active and `# image: kitsuyui/docker-ssh` commented out, but there was no explanation of how to switch between them. Users relying on the Docker Hub pre-built image had to infer the swap from context.

This PR adds a three-line comment block at the top of `docker-compose.yml` explaining the choice: keep `build: .` for local development, or comment it out and uncomment `image: kitsuyui/docker-ssh` to use the Docker Hub image.

## Changes

- `docker-compose.yml`: added a header comment documenting the `build` vs `image` switching pattern

## Verification

- `docker compose config` validates the YAML is still well-formed (existing `version:` deprecation warning is pre-existing)
- The comment adds no runtime behaviour change
